### PR TITLE
Add GitHub Action to build merges into master

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -16,9 +16,9 @@ jobs:
 
     steps:
     - uses: actions/checkout@v2
-    - name: Set up JDK 1.8
+    - name: Set up JDK 11
       uses: actions/setup-java@v1
       with:
-        java-version: 1.8
+        java-version: 11
     - name: Build with Maven
       run: mvn -B package --file pom.xml


### PR DESCRIPTION
This GitHub action will compile the project when a pull request is opened, which is another safety measure to ensure that the code builds before it is merged. We can set up another branch protection to require that this action runs successfully (in addition to human review) before merging the PR.